### PR TITLE
Make license multiline

### DIFF
--- a/example/example.yaml
+++ b/example/example.yaml
@@ -1,7 +1,9 @@
 name: example
 os-type: GNU/Linux
 homepage: https://example.org
-license: GLPv2
+license:
+  - GLPv2
+  - BSD-2-Clause
 release: 2004
 based-on:
   - Debian

--- a/example/example.yaml
+++ b/example/example.yaml
@@ -32,7 +32,7 @@ description:
 images:
   - https://www.debian.org/Pics/debian-logo-1024x576.png
 
-# sourced
+# sources
 # os-type: https://en.wikipedia.org/imaginary-article
 # license: https://www.not-a-website.xyz
 # ...

--- a/example/example.yaml
+++ b/example/example.yaml
@@ -31,3 +31,10 @@ description:
   - example second line
 images:
   - https://www.debian.org/Pics/debian-logo-1024x576.png
+
+# sourced
+# os-type: https://en.wikipedia.org/imaginary-article
+# license: https://www.not-a-website.xyz
+# ...
+# ...
+# ...


### PR DESCRIPTION
Make license in example/example.yaml multiline to allow multiple licences
This is needed cause often distros are made up of multiple custom components that are licensed differently